### PR TITLE
Add registry to Docker login step in workflow

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -11,6 +11,7 @@ jobs:
       - name: Login To GHCR
         uses: docker/login-action@v3
         with:
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU


### PR DESCRIPTION
Specified the `registry` input in the Docker login action to explicitly set GHCR (GitHub Container Registry). This ensures proper authentication and avoids potential ambiguities in multi-registry setups.