### PR TITLE
Set forward headers strategy and improve proxy compatibility

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -3,6 +3,9 @@ spring.docker.compose.enabled=false
 allowed.origins.patterns=${ALLOWED_ORIGINS_PATTERNS}
 
 spring.datasource.url=jdbc:postgresql://postgres:5432/${DB_NAME}
+
+server.forward-headers-strategy=framework
+
 spring.datasource.username=${POSTGRES_USER}
 spring.datasource.password=${POSTGRES_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
```
### Summary
This pull request implements the following changes:
1. Sets the `server.forward-headers-strategy` property to `framework` in the production configuration for proper handling of forwarded headers.
2. Refactors the roles initialization by defining default roles directly in the codebase for enhanced clarity and maintainability.
3. Updates the Nginx proxy configuration to add necessary headers for forwarding and authentication.
4. Ensures Docker Compose defines Nginx as dependent on the Spring service to establish proper service startup order.

### Checklist
- [ ] Testing performed where necessary.
- [ ] Documentation updated as appropriate to reflect changes.
- [ ] Confirmed compatibility with existing functionalities.
```