### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -1,4 +1,6 @@
 name: Run Maven Tests
+permissions:
+  contents: read
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/Day-fit/Florae/security/code-scanning/3](https://github.com/Day-fit/Florae/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only reads repository contents (e.g., checking out code and running Maven tests), the minimal required permission is `contents: read`. This ensures the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
