### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
 
     defaults:
       run:


### PR DESCRIPTION
Potential fix for [https://github.com/Day-fit/Florae/security/code-scanning/2](https://github.com/Day-fit/Florae/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow deploys to GitHub Pages, it requires `pages: write` permission. Other permissions, such as `contents: read`, may be necessary for reading repository contents during the build process. 

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`build-and-deploy`) to limit permissions to that job only. In this case, adding it at the job level is more precise.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
