### PR TITLE
Enhance CSRF protection by using CookieCsrfTokenRepository

### DIFF
--- a/src/main/java/pl/Dayfit/Florae/Configurations/SecurityConfiguration.java
+++ b/src/main/java/pl/Dayfit/Florae/Configurations/SecurityConfiguration.java
@@ -15,7 +15,6 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -24,6 +23,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.web.filter.ForwardedHeaderFilter;
 import pl.Dayfit.Florae.Auth.ApiKeyAuthenticationCandidate;
 import pl.Dayfit.Florae.Auth.ApiKeyAuthenticationToken;
@@ -88,7 +88,7 @@ public class SecurityConfiguration {
     public SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationManager authManager) throws Exception
     {
         return http
-                .csrf(AbstractHttpConfigurer::disable)
+                .csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()))
                 .authorizeHttpRequests(request -> {
                     request.dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll(); //To allow the async servlet to work properly
                     request.requestMatchers(PUBLIC_PATHS.toArray(new String[0])).permitAll();
@@ -170,9 +170,8 @@ public class SecurityConfiguration {
     @Bean
     public AuthenticationProvider daoAuthenticationProvider()
     {
-        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider(userDetailsService);
         provider.setPasswordEncoder(bCryptPasswordEncoder());
-        provider.setUserDetailsService(userDetailsService);
         return provider;
     }
 


### PR DESCRIPTION
This pull request updates the `SecurityConfiguration` class in the `Florae` module to enhance security and simplify authentication configuration. The most important changes include enabling CSRF protection with a cookie-based token repository, modifying the `DaoAuthenticationProvider` initialization, and removing unused imports.

### Security Enhancements:
* Updated CSRF configuration to use `CookieCsrfTokenRepository` with `HttpOnly` set to false for better CSRF protection. (`[src/main/java/pl/Dayfit/Florae/Configurations/SecurityConfiguration.javaL91-R91](diffhunk://#diff-1967fe64d154635629d9d21103c6c0a7b4cbbe4b8b1bdf4cfc167fe939495141L91-R91)`)
* Added an import for `CookieCsrfTokenRepository` to support the new CSRF configuration. (`[src/main/java/pl/Dayfit/Florae/Configurations/SecurityConfiguration.javaR26](diffhunk://#diff-1967fe64d154635629d9d21103c6c0a7b4cbbe4b8b1bdf4cfc167fe939495141R26)`)

### Authentication Configuration:
* Modified the `DaoAuthenticationProvider` initialization to directly set the `userDetailsService` in the constructor, simplifying the configuration. (`[src/main/java/pl/Dayfit/Florae/Configurations/SecurityConfiguration.javaL173-L175](diffhunk://#diff-1967fe64d154635629d9d21103c6c0a7b4cbbe4b8b1bdf4cfc167fe939495141L173-L175)`)

### Code Cleanup:
* Removed the unused import for `AbstractHttpConfigurer` to tidy up the code. (`[src/main/java/pl/Dayfit/Florae/Configurations/SecurityConfiguration.javaL18](diffhunk://#diff-1967fe64d154635629d9d21103c6c0a7b4cbbe4b8b1bdf4cfc167fe939495141L18)`)