### PR TITLE
Added minor improvements for csfr logic that should improve the whole proccess

### DIFF
--- a/src/main/java/pl/Dayfit/Florae/Configurations/SecurityConfiguration.java
+++ b/src/main/java/pl/Dayfit/Florae/Configurations/SecurityConfiguration.java
@@ -88,7 +88,12 @@ public class SecurityConfiguration {
     public SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationManager authManager) throws Exception
     {
         return http
-                .csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()))
+                .csrf(csrf -> 
+                    {
+                        csrf.ignoringRequestMatchers("/csrf","/auth/register");
+                        csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
+                    }
+                )
                 .authorizeHttpRequests(request -> {
                     request.dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll(); //To allow the async servlet to work properly
                     request.requestMatchers(PUBLIC_PATHS.toArray(new String[0])).permitAll();

--- a/src/main/java/pl/Dayfit/Florae/Controllers/CsrfController.java
+++ b/src/main/java/pl/Dayfit/Florae/Controllers/CsrfController.java
@@ -2,16 +2,13 @@ package pl.Dayfit.Florae.Controllers;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.web.csrf.CsrfToken;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import lombok.RequiredArgsConstructor;
-
-@Controller
-@RequiredArgsConstructor
+@RestController
 public class CsrfController {
-    @GetMapping
-    public ResponseEntity<?> getCsrfToken(CsrfToken csrfToken)
+    @GetMapping("/csrf")
+    public ResponseEntity<CsrfToken> getCsrfToken(CsrfToken csrfToken)
     {
         return ResponseEntity.ok(csrfToken);
     }

--- a/src/main/java/pl/Dayfit/Florae/Controllers/CsrfController.java
+++ b/src/main/java/pl/Dayfit/Florae/Controllers/CsrfController.java
@@ -1,0 +1,18 @@
+package pl.Dayfit.Florae.Controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class CsrfController {
+    @GetMapping
+    public ResponseEntity<?> getCsrfToken(CsrfToken csrfToken)
+    {
+        return ResponseEntity.ok(csrfToken);
+    }
+}


### PR DESCRIPTION
This pull request introduces changes to enhance CSRF (Cross-Site Request Forgery) handling in the application. It modifies the security configuration to exclude specific endpoints from CSRF protection and adds a new controller to retrieve CSRF tokens.

### Enhancements to CSRF handling:

* [`src/main/java/pl/Dayfit/Florae/Configurations/SecurityConfiguration.java`](diffhunk://#diff-1967fe64d154635629d9d21103c6c0a7b4cbbe4b8b1bdf4cfc167fe939495141L91-R96): Updated the `securityFilterChain` method to exclude `/csrf` and `/auth/register` endpoints from CSRF protection and improve the configuration for CSRF token repository.

* [`src/main/java/pl/Dayfit/Florae/Controllers/CsrfController.java`](diffhunk://#diff-f8bdbc63bb80a25bb4c4c2105d25dc2926d7e8b39ba8a87ebb2f6255dd211955R1-R18): Added a new `CsrfController` class with a `getCsrfToken` endpoint to retrieve CSRF tokens, enabling better client-side handling of CSRF protection.