### PR TITLE
Migrate cookie handling to `ResponseCookie` with dynamic `SameSite` policy support, update configuration for FLEXIBLE DEV & PROD set

### DIFF
--- a/florae-frontend/.env.development
+++ b/florae-frontend/.env.development
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:8080
+VITE_API_URL=

--- a/florae-frontend/vite.config.js
+++ b/florae-frontend/vite.config.js
@@ -9,6 +9,21 @@ export default defineConfig({
     outDir: "dist",
   },
 
+  server: {
+    proxy: {
+      '/auth': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        secure: false,
+      },
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
+
   plugins: [
     react(),
     tailwindcss(),

--- a/src/main/java/pl/Dayfit/Florae/Controllers/FloraeUserController.java
+++ b/src/main/java/pl/Dayfit/Florae/Controllers/FloraeUserController.java
@@ -62,7 +62,7 @@ public class FloraeUserController {
 
     @Value("${florae.secured-cookies.enabled:false}")
     private boolean useSecuredCookies;
-    @Value("${florae.cookie.policy}")
+    @Value("${florae.cookie.policy:lax}")
     private String cookiePolicy;
 
     private static final String USERNAME_REGEX = "[a-zA-Z0-9_]+";

--- a/src/main/java/pl/Dayfit/Florae/Controllers/FloraeUserController.java
+++ b/src/main/java/pl/Dayfit/Florae/Controllers/FloraeUserController.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -60,6 +62,8 @@ public class FloraeUserController {
 
     @Value("${florae.secured-cookies.enabled:false}")
     private boolean useSecuredCookies;
+    @Value("${florae.cookie.policy}")
+    private String cookiePolicy;
 
     private static final String USERNAME_REGEX = "[a-zA-Z0-9_]+";
     private static final String EMAIL_REGEX = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
@@ -120,22 +124,26 @@ public class FloraeUserController {
         }
 
         if (floraeUserLoginDTO.getGenerateRefreshToken()) {
-            Cookie refreshTokenCookie = new Cookie("refreshToken", floraeUserService.getRefreshToken(user.getUsername()));
-            refreshTokenCookie.setPath("/");
-            refreshTokenCookie.setMaxAge(60 * 60 * 24 * FloraeUserService.REFRESH_TOKEN_EXPIRATION_TIME);
-            refreshTokenCookie.setHttpOnly(true);
-            refreshTokenCookie.setSecure(useSecuredCookies);
+            ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", floraeUserService.getRefreshToken(user.getUsername()))
+                    .path("/")
+                    .sameSite(cookiePolicy)
+                    .maxAge(60 * 60 * 24 * FloraeUserService.REFRESH_TOKEN_EXPIRATION_TIME)
+                    .httpOnly(true)
+                    .secure(useSecuredCookies)
+                    .build();
 
-            response.addCookie(refreshTokenCookie);
+            response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
         }
 
-        Cookie accessTokenCookie = new Cookie("accessToken", floraeUserService.generateAccessToken(user.getUsername()));
-        accessTokenCookie.setPath("/");
-        accessTokenCookie.setMaxAge(60 * FloraeUserService.ACCESS_TOKEN_EXPIRATION_TIME);
-        accessTokenCookie.setHttpOnly(true);
-        accessTokenCookie.setSecure(useSecuredCookies);
+        ResponseCookie accessTokenCookie = ResponseCookie.from("accessToken", floraeUserService.generateAccessToken(user.getUsername()))
+                .path("/")
+                .maxAge(60 * FloraeUserService.ACCESS_TOKEN_EXPIRATION_TIME)
+                .sameSite(cookiePolicy)
+                .httpOnly(true)
+                .secure(useSecuredCookies)
+                .build();
 
-        response.addCookie(accessTokenCookie);
+        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
 
         return ResponseEntity.ok(Map.of("message", "User logged in successfully"));
     }
@@ -167,13 +175,15 @@ public class FloraeUserController {
 
         String newAccessToken = floraeUserService.refreshAccessToken(refreshToken);
 
-        Cookie accessTokenCookie = new Cookie("accessToken", newAccessToken);
-        accessTokenCookie.setSecure(useSecuredCookies);
-        accessTokenCookie.setHttpOnly(true);
-        accessTokenCookie.setPath("/");
-        accessTokenCookie.setMaxAge(60 * FloraeUserService.ACCESS_TOKEN_EXPIRATION_TIME);
+        ResponseCookie accessTokenCookie = ResponseCookie.from("accessToken", newAccessToken)
+                .path("/")
+                .maxAge(60 * FloraeUserService.ACCESS_TOKEN_EXPIRATION_TIME)
+                .sameSite(cookiePolicy)
+                .httpOnly(true)
+                .secure(useSecuredCookies)
+                .build();
 
-        response.addCookie(accessTokenCookie);
+        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
 
         return ResponseEntity.ok(Map.of("message","Access token refreshed successfully"));
     }
@@ -189,8 +199,6 @@ public class FloraeUserController {
         {
             return ResponseEntity.ok(Map.of("message", "Already logged out"));
         }
-
-
 
         for (Cookie cookie : cookies)
         {
@@ -215,25 +223,29 @@ public class FloraeUserController {
         String refreshToken = refreshTokenCookie != null ? refreshTokenCookie.getValue() : null;
 
         if (refreshToken != null && !refreshToken.isBlank() && jwtService.validateRefreshToken(refreshToken)) {
-            Cookie deletedRefreshTokenCookie = new Cookie("refreshToken", null);
-            deletedRefreshTokenCookie.setPath("/");
-            deletedRefreshTokenCookie.setMaxAge(0);
-            deletedRefreshTokenCookie.setHttpOnly(true);
-            deletedRefreshTokenCookie.setSecure(useSecuredCookies);
+            ResponseCookie deletedRefreshTokenCookie = ResponseCookie.from("refreshToken", "")
+                    .path("/")
+                    .maxAge(0)
+                    .sameSite(cookiePolicy)
+                    .httpOnly(true)
+                    .secure(useSecuredCookies)
+                    .build();
 
-            response.addCookie(deletedRefreshTokenCookie);
+            response.addHeader(HttpHeaders.SET_COOKIE, deletedRefreshTokenCookie.toString());
 
             jwtService.revokeToken(refreshToken);
         }
 
         if (accessToken != null && !accessToken.isBlank() && jwtService.validateAccessToken(accessToken, user.getUsername())) {
-            Cookie deletedAccessToken = new Cookie("accessToken", null);
-            deletedAccessToken.setPath("/");
-            deletedAccessToken.setMaxAge(0);
-            deletedAccessToken.setHttpOnly(true);
-            deletedAccessToken.setSecure(useSecuredCookies);
+            ResponseCookie deletedAccessToken = ResponseCookie.from("accessToken", "")
+                    .path("/")
+                    .maxAge(0)
+                    .sameSite(cookiePolicy)
+                    .httpOnly(true)
+                    .secure(useSecuredCookies)
+                    .build();
 
-            response.addCookie(deletedAccessToken);
+            response.addHeader(HttpHeaders.SET_COOKIE, deletedAccessToken.toString());
 
             jwtService.revokeToken(accessToken);
         }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -6,3 +6,5 @@ spring.jpa.hibernate.ddl-auto=create-drop
 
 florae.forwarded-headers.enabled=false
 florae.secured-cookies.enabled=false
+
+florae.cookie.policy = "lax";

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -5,7 +5,8 @@ allowed.origins.patterns=${ALLOWED_ORIGINS_PATTERNS}
 spring.datasource.url=jdbc:postgresql://postgres:5432/${DB_NAME}
 
 server.forward-headers-strategy=framework
-server.servlet.session.cookie.same-site=lax
+
+florae.cookie.policy = "none";
 
 spring.datasource.username=${POSTGRES_USER}
 spring.datasource.password=${POSTGRES_PASSWORD}


### PR DESCRIPTION
This pull request introduces changes to enhance cookie handling, update proxy configurations, and improve security settings in both the frontend and backend of the `Florae` application. The most significant modifications involve replacing `Cookie` with `ResponseCookie` for better control over cookie attributes, adding a proxy server configuration for development, and introducing a configurable cookie policy.

### Backend Changes: Cookie Handling and Security

* **Replaced `Cookie` with `ResponseCookie` in `FloraeUserController`:** Updated methods for login, token refresh, and logout to use `ResponseCookie` instead of `Cookie`, enabling finer control over attributes like `sameSite`, `secure`, and `httpOnly`. Added support for configurable cookie policies (`florae.cookie.policy`) to enhance flexibility. [[1]](diffhunk://#diff-b2d60aff8d9e23fa9596de44b77abfd878cca1cba3d1eb7cdd04ac6c6aa16698L123-R146) [[2]](diffhunk://#diff-b2d60aff8d9e23fa9596de44b77abfd878cca1cba3d1eb7cdd04ac6c6aa16698L170-R186) [[3]](diffhunk://#diff-b2d60aff8d9e23fa9596de44b77abfd878cca1cba3d1eb7cdd04ac6c6aa16698L218-R248)

* **Introduced `cookiePolicy` configuration:** Added a new `@Value` field in `FloraeUserController` to retrieve the cookie policy from application properties. This ensures the cookie behavior can be customized for different environments.

* **Updated application properties for cookie policy:** Added `florae.cookie.policy` settings in `application-dev.properties` and `application-prod.properties` to specify `lax` for development and `none` for production environments. [[1]](diffhunk://#diff-cbee934a0dc2d724591feb74d9e4200e997b60b1f2b2a41b51336a0c83ab42b9R9-R10) [[2]](diffhunk://#diff-53e0fee6660a4a2a0f74370f5a08f37733746fd612eca8c9df7ebd0dfdb613efL8-R9)

### Frontend Changes: Proxy Configuration

* **Added proxy settings in `vite.config.js`:** Configured a development proxy for `/auth` and `/api` endpoints to route requests to `http://localhost:8080`. This simplifies API calls during development by avoiding cross-origin issues.

* **Removed hardcoded `VITE_API_URL` in `.env.development`:** Cleared the `VITE_API_URL` value to allow flexibility in API endpoint configuration.tings, and refine the frontend proxy for API requests.