### PR TITLE
Add permissions to deploy-frontend.yml and include a fixed version of spring-context dependency in pom.xml

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,5 +1,8 @@
 name: Build and Deploy React app via SSH
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@
 		    <artifactId>tomcat-embed-core</artifactId>
 		    <version>11.0.7</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+			<version>6.2.7</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>


### PR DESCRIPTION
This pull request includes updates to the deployment configuration and project dependencies. The most important changes involve adding permissions for GitHub Actions and introducing a new dependency in the `pom.xml` file.

### Deployment Configuration Updates:
* [`.github/workflows/deploy-frontend.yml`](diffhunk://#diff-64f2f74f4d05399d57c48809ad9ec9bc55550bd51d5faf574866753ea4d781dbR3-R5): Added `contents: write` permissions to enable GitHub Actions to modify repository contents during the deployment process.

### Dependency Updates:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R123-R127): Added `spring-context` dependency with version `6.2.7` to enhance the project's Spring framework capabilities.