### PR TITLE
Enhance FloraLink and API key management:

### DIFF
--- a/src/main/java/pl/Dayfit/Florae/Controllers/ApiKeyController.java
+++ b/src/main/java/pl/Dayfit/Florae/Controllers/ApiKeyController.java
@@ -1,13 +1,15 @@
 package pl.Dayfit.Florae.Controllers;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CachePut;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import pl.Dayfit.Florae.Auth.UserPrincipal;
+import pl.Dayfit.Florae.DTOs.GenerateApiKeyDTO;
+import pl.Dayfit.Florae.Entities.Plant;
 import pl.Dayfit.Florae.Services.Auth.API.ApiKeyService;
+import pl.Dayfit.Florae.Services.PlantCacheService;
 
 import java.util.Map;
 
@@ -26,12 +28,23 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class ApiKeyController {
     private final ApiKeyService apiKeyService;
+    private final PlantCacheService plantCacheService;
 
-    @CachePut(value = "api-keys", key = "#userPrincipal.username")
     @PostMapping("/api/v1/generate-key")
-    public ResponseEntity<Map<String, String>> generateApiKey(@AuthenticationPrincipal UserPrincipal userPrincipal)
+    public ResponseEntity<Map<String, String>> generateApiKey(@RequestBody GenerateApiKeyDTO apiKeyDTO, @AuthenticationPrincipal UserPrincipal userPrincipal)
     {
-        return ResponseEntity.ok(Map.of("apiKey", apiKeyService.generateApiKey(userPrincipal.getUsername())));
+        Plant plant = plantCacheService.getPlantById(apiKeyDTO.getPlantId());
+
+        if (plant == null)
+        {
+            return ResponseEntity.badRequest().body(Map.of("error", "Invalid plant id"));
+        }
+
+        try {
+            return ResponseEntity.ok(Map.of("apiKey", apiKeyService.generateApiKey(userPrincipal.getUsername(), plant)));
+        } catch (IllegalArgumentException exception) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("error", exception.getMessage()));
+        }
     }
 
     @DeleteMapping("/api/v1/revoke-key")

--- a/src/main/java/pl/Dayfit/Florae/Controllers/FloraLinkController.java
+++ b/src/main/java/pl/Dayfit/Florae/Controllers/FloraLinkController.java
@@ -10,11 +10,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import pl.Dayfit.Florae.Auth.UserPrincipal;
+import pl.Dayfit.Florae.DTOs.FloraLinkSetNameDTO;
 import pl.Dayfit.Florae.DTOs.Sensors.CurrentSensorDataDTO;
 import pl.Dayfit.Florae.DTOs.Sensors.DailySensorDataDTO;
 import pl.Dayfit.Florae.Services.Auth.API.ApiKeyService;
@@ -37,10 +35,9 @@ public class FloraLinkController {
     @PostMapping("/api/v1/floralink/connect-api")
     public ResponseEntity<?> connectApi(Authentication authentication)
     {
-        try{
+        try {
             apiKeyService.connectApi(authentication);
-        } catch (IllegalStateException exception)
-        {
+        } catch (IllegalStateException exception) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", exception.getMessage()));
         }
         return ResponseEntity.ok(Map.of("message", "API connected successfully."));
@@ -64,6 +61,23 @@ public class FloraLinkController {
     {
         floraLinkService.handleCurrentDataUpload(uploadedData, authentication);
         return ResponseEntity.ok(Map.of("message", "Data uploaded successfully."));
+    }
+
+    @PostMapping("/api/v1/floralink/set-name")
+    public ResponseEntity<?> setFloraLinkName(@RequestBody FloraLinkSetNameDTO floraLinkSetNameDTO, @AuthenticationPrincipal UserPrincipal userPrincipal)
+    {
+        if (floraLinkSetNameDTO == null || floraLinkSetNameDTO.getId() == null || floraLinkSetNameDTO.getName() == null || floraLinkSetNameDTO.getName().isBlank())
+        {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", "Incorrect request body"));
+        }
+
+        try {
+            floraLinkService.setName(floraLinkSetNameDTO, userPrincipal.getUsername());
+        } catch (IllegalArgumentException exception) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("error", exception.getMessage()));
+        }
+
+        return ResponseEntity.ok(Map.of("message", "Name set successfully."));
     }
 
     @GetMapping("/api/v1/floralink/get-all-current-data")

--- a/src/main/java/pl/Dayfit/Florae/Controllers/FloraLinkController.java
+++ b/src/main/java/pl/Dayfit/Florae/Controllers/FloraLinkController.java
@@ -73,7 +73,7 @@ public class FloraLinkController {
 
         try {
             floraLinkService.setName(floraLinkSetNameDTO, userPrincipal.getUsername());
-        } catch (IllegalArgumentException exception) {
+        } catch (IllegalStateException exception) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("error", exception.getMessage()));
         }
 

--- a/src/main/java/pl/Dayfit/Florae/Controllers/FloraeUserController.java
+++ b/src/main/java/pl/Dayfit/Florae/Controllers/FloraeUserController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import pl.Dayfit.Florae.Auth.UserPrincipal;
 import pl.Dayfit.Florae.DTOs.FloraeUserLoginDTO;
 import pl.Dayfit.Florae.DTOs.FloraeUserRegisterDTO;
-import pl.Dayfit.Florae.DTOs.FloraeUserReposonseDTO;
+import pl.Dayfit.Florae.DTOs.FloraeUserResponseDTO;
 import pl.Dayfit.Florae.Entities.FloraeUser;
 import pl.Dayfit.Florae.Services.Auth.JWT.FloraeUserCacheService;
 import pl.Dayfit.Florae.Services.Auth.JWT.FloraeUserService;
@@ -235,7 +235,6 @@ public class FloraeUserController {
 
             jwtService.revokeToken(refreshToken);
         }
-
         if (accessToken != null && !accessToken.isBlank() && jwtService.validateAccessToken(accessToken, user.getUsername())) {
             ResponseCookie deletedAccessToken = ResponseCookie.from("accessToken", "")
                     .path("/")
@@ -266,6 +265,6 @@ public class FloraeUserController {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", "User not found"));
         }
 
-        return ResponseEntity.ok(new FloraeUserReposonseDTO(floraeUser.getUsername(), floraeUser.getEmail()));
+        return ResponseEntity.ok(new FloraeUserResponseDTO(floraeUser.getUsername(), floraeUser.getEmail()));
     }
 }

--- a/src/main/java/pl/Dayfit/Florae/DTOs/FloraLinkResponseDTO.java
+++ b/src/main/java/pl/Dayfit/Florae/DTOs/FloraLinkResponseDTO.java
@@ -1,0 +1,15 @@
+package pl.Dayfit.Florae.DTOs;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FloraLinkResponseDTO {
+    Integer floraLinkId;
+    String name;
+}

--- a/src/main/java/pl/Dayfit/Florae/DTOs/FloraLinkSetNameDTO.java
+++ b/src/main/java/pl/Dayfit/Florae/DTOs/FloraLinkSetNameDTO.java
@@ -1,0 +1,15 @@
+package pl.Dayfit.Florae.DTOs;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FloraLinkSetNameDTO {
+    private Integer id;
+    private String name;
+}

--- a/src/main/java/pl/Dayfit/Florae/DTOs/FloraeUserResponseDTO.java
+++ b/src/main/java/pl/Dayfit/Florae/DTOs/FloraeUserResponseDTO.java
@@ -1,0 +1,13 @@
+package pl.Dayfit.Florae.DTOs;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class FloraeUserResponseDTO {
+    private String username;
+    private String email;
+}

--- a/src/main/java/pl/Dayfit/Florae/DTOs/GenerateApiKeyDTO.java
+++ b/src/main/java/pl/Dayfit/Florae/DTOs/GenerateApiKeyDTO.java
@@ -2,12 +2,13 @@ package pl.Dayfit.Florae.DTOs;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @AllArgsConstructor
-public class FloraeUserReposonseDTO {
-    private String username;
-    private String email;
+public class GenerateApiKeyDTO {
+    private Integer plantId;
 }

--- a/src/main/java/pl/Dayfit/Florae/DTOs/PlantResponseDTO.java
+++ b/src/main/java/pl/Dayfit/Florae/DTOs/PlantResponseDTO.java
@@ -1,7 +1,6 @@
 package pl.Dayfit.Florae.DTOs;
 
 import lombok.Data;
-import pl.Dayfit.Florae.Entities.FloraLink;
 
 @Data
 public class PlantResponseDTO
@@ -10,7 +9,7 @@ public class PlantResponseDTO
     private String owner;
     private String name;
     private String speciesName;
-    private FloraLink linkedFloraLink;
+    private FloraLinkResponseDTO linkedFloraLink;
     private String primaryPhoto;
     private PlantRequirementsDTO requirements;
 }

--- a/src/main/java/pl/Dayfit/Florae/Entities/ApiKey.java
+++ b/src/main/java/pl/Dayfit/Florae/Entities/ApiKey.java
@@ -61,6 +61,10 @@ public class ApiKey {
     @OneToOne
     private FloraLink linkedFloraLink;
 
+    @OneToOne
+    @JoinColumn(nullable = false)
+    private Plant linkedPlant;
+
     @ManyToOne
     private FloraeUser linkedUser;
 }

--- a/src/main/java/pl/Dayfit/Florae/Entities/FloraLink.java
+++ b/src/main/java/pl/Dayfit/Florae/Entities/FloraLink.java
@@ -42,6 +42,10 @@ public class FloraLink {
     @ManyToOne(cascade = CascadeType.ALL)
     private FloraeUser owner;
 
+    @OneToOne
+    @JoinColumn(nullable = false)
+    private Plant linkedPlant;
+
     @OneToOne(mappedBy = "floraLink", cascade = CascadeType.ALL)
     private DailyReportData dailyReportData;
 }

--- a/src/main/java/pl/Dayfit/Florae/Entities/Plant.java
+++ b/src/main/java/pl/Dayfit/Florae/Entities/Plant.java
@@ -37,7 +37,7 @@ public class Plant {
     @Column(nullable = false, length = 50)
     private String pid;
 
-    @OneToOne(cascade = CascadeType.DETACH)
+    @OneToOne(mappedBy = "linkedPlant", cascade = CascadeType.ALL)
     private FloraLink linkedFloraLink;
 
     @ManyToOne

--- a/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/FloraeUserCacheService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/FloraeUserCacheService.java
@@ -6,6 +6,7 @@ import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+import org.springframework.transaction.annotation.Transactional;
 import pl.Dayfit.Florae.Entities.FloraeUser;
 import pl.Dayfit.Florae.Repositories.JPA.FloraeUserRepository;
 
@@ -35,30 +36,35 @@ import pl.Dayfit.Florae.Repositories.JPA.FloraeUserRepository;
 public class FloraeUserCacheService {
     private final FloraeUserRepository userRepository;
 
+    @Transactional(readOnly = true)
     @Cacheable(value = "florae-users", key = "#username")
     public FloraeUser getFloraeUser(String username)
     {
         return userRepository.findByUsername(username);
     }
 
+    @Transactional(readOnly = true)
     @Cacheable(value = "florae-users", key = "#id")
     public FloraeUser getFloraeUserById(int id)
     {
         return userRepository.findById(id).orElse(null);
     }
 
+    @Transactional(readOnly = true)
     @Cacheable(value = "florae-users", key = "#email")
     public FloraeUser getFloraeUserByEmail(String email)
     {
         return userRepository.findByEmail(email);
     }
 
+    @Transactional
     @CachePut(value = "florae-users", key = "#user.id")
     public FloraeUser saveFloraeUser(FloraeUser user)
     {
         return userRepository.save(user);
     }
 
+    @Transactional(readOnly = true)
     @Cacheable(value = "florae-users", key = "{#email, #username}")
     public FloraeUser findByEmailOrUsername(String email, String username)
     {

--- a/src/main/java/pl/Dayfit/Florae/Services/FloraLinkCacheService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/FloraLinkCacheService.java
@@ -5,6 +5,8 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pl.Dayfit.Florae.DTOs.FloraLinkResponseDTO;
 import pl.Dayfit.Florae.Entities.FloraLink;
 import pl.Dayfit.Florae.Repositories.JPA.FloraLinkRepository;
 import pl.Dayfit.Florae.Services.Auth.JWT.FloraeUserCacheService;
@@ -44,12 +46,16 @@ public class FloraLinkCacheService {
         return floraLinkRepository.findById(floraLinkId).orElse(null);
     }
 
+    @Transactional(readOnly = true)
     @Cacheable(value = "flora-links", key = "#ownerId")
-    public List<FloraLink> getOwnedFloraLinks(Integer ownerId)
+    public List<FloraLinkResponseDTO> getOwnedFloraLinks(Integer ownerId)
     {
-        return floraLinkRepository.findByOwner(floraeUserCacheService.getFloraeUserById(ownerId));
+        return floraLinkRepository.findByOwner(floraeUserCacheService.getFloraeUserById(ownerId)).stream().map(
+                floraLink -> new FloraLinkResponseDTO(floraLink.getId(), floraLink.getName())
+        ).toList();
     }
 
+    @Transactional
     @CacheEvict(value = "flora-links", key = "#result.owner.id")
     @CachePut(value = "flora-link", key = "#floraLink.id")
     public FloraLink saveFloraLink(FloraLink floraLink)

--- a/src/main/java/pl/Dayfit/Florae/Services/PlantCacheService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/PlantCacheService.java
@@ -5,6 +5,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import pl.Dayfit.Florae.Entities.Plant;
 import pl.Dayfit.Florae.Repositories.JPA.PlantRepository;
 
@@ -17,6 +18,7 @@ import pl.Dayfit.Florae.Repositories.JPA.PlantRepository;
 public class PlantCacheService {
     private final PlantRepository plantRepository;
 
+    @Transactional(readOnly = true)
     @Cacheable(value = "plants", key = "#id")
     public Plant getPlantById(int id)
     {

--- a/src/main/java/pl/Dayfit/Florae/Services/PlantsService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/PlantsService.java
@@ -21,8 +21,10 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
+import pl.Dayfit.Florae.DTOs.FloraLinkResponseDTO;
 import pl.Dayfit.Florae.DTOs.PlantRequirementsDTO;
 import pl.Dayfit.Florae.DTOs.PlantResponseDTO;
+import pl.Dayfit.Florae.Entities.FloraLink;
 import pl.Dayfit.Florae.Entities.FloraeUser;
 import pl.Dayfit.Florae.Entities.Plant;
 import pl.Dayfit.Florae.DTOs.PlantFetchDTO;
@@ -109,12 +111,6 @@ public class PlantsService {
         throw new IllegalStateException("No matches found");
     }
 
-    public PlantResponseDTO getPlantById(Integer id)
-    {
-        Plant plant = plantRepository.findById(id).orElse(null);
-        return mapPlantDTO(plant);
-    }
-
     @Transactional(readOnly = true)
     public List<PlantResponseDTO> getPlantsByUsername(String username)
     {
@@ -133,6 +129,14 @@ public class PlantsService {
             return null;
         }
 
+        FloraLink floraLink = plant.getLinkedFloraLink();
+        FloraLinkResponseDTO floraLinkResponseDTO = null;
+
+        if(floraLink != null)
+        {
+            floraLinkResponseDTO = new FloraLinkResponseDTO(floraLink.getId(), floraLink.getName());
+        }
+
         PlantRequirements plantRequirements = plant.getRequirements();
         PlantResponseDTO mappedElement = new PlantResponseDTO();
         mappedElement.setId(plant.getId());
@@ -140,7 +144,7 @@ public class PlantsService {
         mappedElement.setName(plant.getName());
         mappedElement.setSpeciesName(plant.getSpeciesName());
         mappedElement.setPrimaryPhoto(plant.getPrimaryPhoto());
-        mappedElement.setLinkedFloraLink(plant.getLinkedFloraLink());
+        mappedElement.setLinkedFloraLink(floraLinkResponseDTO);
         mappedElement.setRequirements(
                 new PlantRequirementsDTO(
                         null,


### PR DESCRIPTION
- Add `FloraLinkResponseDTO` and `FloraLinkSetNameDTO`.
- Update `FloraLinkController` with endpoint for setting FloraLink name.
- Link `Plant` entities with FloraLink and API keys.
- Introduce `GenerateApiKeyDTO` for plant-specific API key generation.
- Improve APIs to validate ownership and linking rules for plants and FloraLinks.
- Refactor services and caching layers for consistency, transactional support, and streamlined responses.