### PR TITLE
Fixed vulnerabilities by updating postgres driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,11 @@
 			<artifactId>commons-codec</artifactId>
 			<version>1.18.0</version>
 		</dependency>
+		<dependency>
+		    <groupId>org.postgresql</groupId>
+		    <artifactId>postgresql</artifactId>
+		    <version>42.7.7</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>


### PR DESCRIPTION
This pull request introduces a small but important change to the `pom.xml` file by adding a new dependency for PostgreSQL.

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R133-R137): Added the PostgreSQL dependency (`org.postgresql:postgresql`) with version `42.7.7` to the project dependencies.