### PR TITLE
Jwt secret rotation

### DIFF
--- a/src/main/java/pl/Dayfit/Florae/Auth/FloraeKeyLocator.java
+++ b/src/main/java/pl/Dayfit/Florae/Auth/FloraeKeyLocator.java
@@ -1,0 +1,26 @@
+package pl.Dayfit.Florae.Auth;
+
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Locator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import pl.Dayfit.Florae.Services.Auth.JWT.SecretKeysService;
+
+import java.security.Key;
+
+@Component
+@RequiredArgsConstructor
+public class FloraeKeyLocator implements Locator<Key> {
+    private final SecretKeysService secretKeysService;
+
+    @Override
+    public Key locate(Header header) {
+        Object keyId = header.get("keyId");
+        if (!(keyId instanceof Integer keyIndex)) {
+            throw new JwtException("Invalid key ID header value: " + keyId);
+        }
+
+        return secretKeysService.getCurrentSecret(keyIndex);
+    }
+}

--- a/src/main/java/pl/Dayfit/Florae/Auth/FloraeKeyLocator.java
+++ b/src/main/java/pl/Dayfit/Florae/Auth/FloraeKeyLocator.java
@@ -9,11 +9,22 @@ import pl.Dayfit.Florae.Services.Auth.JWT.SecretKeysService;
 
 import java.security.Key;
 
+/**
+ * Component responsible for localizing the correct SecretKey
+ * based on the `keyId` in JWT token headers
+ */
 @Component
 @RequiredArgsConstructor
 public class FloraeKeyLocator implements Locator<Key> {
     private final SecretKeysService secretKeysService;
 
+    /**
+     * Localize the SecretKey based on the `keyId` in the header
+     *
+     * @param header the JWT header to inspect
+     * @return Secret key based on `keyId`
+     * @throws JwtException if the `keyId` is invalid
+     */
     @Override
     public Key locate(Header header) {
         Object keyId = header.get("keyId");

--- a/src/main/java/pl/Dayfit/Florae/Events/JWTRotationEvent.java
+++ b/src/main/java/pl/Dayfit/Florae/Events/JWTRotationEvent.java
@@ -1,0 +1,4 @@
+package pl.Dayfit.Florae.Events;
+
+public record JWTRotationEvent() {
+}

--- a/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/JWTRotationService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/JWTRotationService.java
@@ -12,7 +12,7 @@ import pl.Dayfit.Florae.Events.JWTRotationEvent;
 @RequiredArgsConstructor
 public class JWTRotationService {
     private final ApplicationEventPublisher eventPublisher;
-    private static final int SECRET_KEY_ROTATION_INTERVAL = 1000 * 60 * 60 * 24; //One day
+    private static final long SECRET_KEY_ROTATION_INTERVAL = TimeUnit.DAYS.toMillis(1); //One day
 
     @Scheduled(fixedRate = SECRET_KEY_ROTATION_INTERVAL)
     private void handleJwtSecretKeyRotation()

--- a/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/JWTRotationService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/JWTRotationService.java
@@ -1,0 +1,24 @@
+package pl.Dayfit.Florae.Services.Auth.JWT;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import pl.Dayfit.Florae.Events.JWTRotationEvent;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JWTRotationService {
+    private final ApplicationEventPublisher eventPublisher;
+    private static final int SECRET_KEY_ROTATION_INTERVAL = 1000 * 60 * 60 * 24; //One day
+
+    @Scheduled(fixedRate = SECRET_KEY_ROTATION_INTERVAL)
+    private void handleJwtSecretKeyRotation()
+    {
+        log.info("Handling JWT secret key rotation...");
+        eventPublisher.publishEvent(new JWTRotationEvent());
+        log.info("Rotation ended successfully.");
+    }
+}

--- a/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/JWTRotationService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/JWTRotationService.java
@@ -7,13 +7,20 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import pl.Dayfit.Florae.Events.JWTRotationEvent;
 
+/**
+ * Service responsible for publishing the `JWTRotationEvent` based on the `SECRET_KEY_ROTATION_INTERVAL` value
+ */
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class JWTRotationService {
     private final ApplicationEventPublisher eventPublisher;
-    private static final long SECRET_KEY_ROTATION_INTERVAL = TimeUnit.DAYS.toMillis(1); //One day
+    private static final int SECRET_KEY_ROTATION_INTERVAL = 1000 * 60 * 60 * 24; //One day
 
+    /**
+     * Publish the `JWTRotationEvent` event
+     */
     @Scheduled(fixedRate = SECRET_KEY_ROTATION_INTERVAL)
     private void handleJwtSecretKeyRotation()
     {

--- a/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/JWTService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/JWTService.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 
  * <p>Annotations:
  * <ul>
+ *     <li>{@code @Slf4j}: Enables logging in class</li>
  *     <li>{@code @Service}: Indicates that this class is a Spring service component.</li>
  * </ul>
 

--- a/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/JWTService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/JWTService.java
@@ -148,7 +148,7 @@ public class JWTService {
      * @param token The JWT access token to be validated.
      * @param username The username associated with the token.
      *
-     * @return {@code true} if the token is valid, an owner is correct and not expired or blacklisted, {@code false} otherwise.
+     * @return {@code true} if the token is valid, the owner is correct and not expired or blacklisted, {@code false} otherwise.
      */
     public boolean validateAccessToken(String token, String username) {
         String extractUsername = extractUsername(token);

--- a/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/SecretKeysService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/SecretKeysService.java
@@ -1,6 +1,7 @@
 package pl.Dayfit.Florae.Services.Auth.JWT;
 
 import io.jsonwebtoken.security.Keys;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
@@ -14,12 +15,19 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Service responsible for managing the SecretKeys
+ */
 @Slf4j
 @Service
 public class SecretKeysService {
     private final AtomicInteger currentSecretKeyIndex = new AtomicInteger(-1);
-    private final ConcurrentMap<Integer, String> secretKeys = new ConcurrentHashMap<>();
+    private @Setter ConcurrentMap<Integer, String> secretKeys = new ConcurrentHashMap<>();
 
+    /**
+     * Generates a new SecretKey when the `JWTRotationEvent` is being published
+     * @param event the `JWTRotationEvent` event instance
+     */
     @EventListener
     @SuppressWarnings("unused")
     private void handleSecretKeyGeneration(JWTRotationEvent event)
@@ -56,5 +64,10 @@ public class SecretKeysService {
     public SecretKey getCurrentSecret(Integer index) {
         byte[] keyBytes = Base64.getDecoder().decode(secretKeys.get(index));
         return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public void setCurrentSecretKeyIndex(int index)
+    {
+        currentSecretKeyIndex.set(index);
     }
 }

--- a/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/SecretKeysService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/SecretKeysService.java
@@ -1,0 +1,60 @@
+package pl.Dayfit.Florae.Services.Auth.JWT;
+
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import pl.Dayfit.Florae.Events.JWTRotationEvent;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Slf4j
+@Service
+public class SecretKeysService {
+    private final AtomicInteger currentSecretKeyIndex = new AtomicInteger(-1);
+    private final ConcurrentMap<Integer, String> secretKeys = new ConcurrentHashMap<>();
+
+    @EventListener
+    @SuppressWarnings("unused")
+    private void handleSecretKeyGeneration(JWTRotationEvent event)
+    {
+        int MAX_SECRET_KEYS = FloraeUserService.REFRESH_TOKEN_EXPIRATION_TIME + 1;
+        int index = (currentSecretKeyIndex.get() + 1) % MAX_SECRET_KEYS;
+
+        try {
+            KeyGenerator generator = KeyGenerator.getInstance("HmacSHA256");
+            secretKeys.put(index, Base64.getEncoder().encodeToString(generator.generateKey().getEncoded()));
+            currentSecretKeyIndex.set(index);
+        } catch (NoSuchAlgorithmException exception) {
+            log.error("A runtime error occurred while generating a secret key for index {}: {}", index, exception.getMessage());
+            System.exit(1);
+        }
+    }
+
+    public SecretKey getCurrentSecretKey()
+    {
+        int index = currentSecretKeyIndex.get();
+        if (index < 0)
+        {
+            return null;
+        }
+
+        return Keys.hmacShaKeyFor(Base64.getDecoder().decode(secretKeys.get(index)));
+    }
+
+    public int getCurrentSecretKeyIndex()
+    {
+        return currentSecretKeyIndex.get();
+    }
+
+    public SecretKey getCurrentSecret(Integer index) {
+        byte[] keyBytes = Base64.getDecoder().decode(secretKeys.get(index));
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+}

--- a/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/SecretKeysService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/SecretKeysService.java
@@ -33,7 +33,7 @@ public class SecretKeysService {
             currentSecretKeyIndex.set(index);
         } catch (NoSuchAlgorithmException exception) {
             log.error("A runtime error occurred while generating a secret key for index {}: {}", index, exception.getMessage());
-            System.exit(1);
+            throw new RuntimeException("Failed to generate secret key for index " + index, exception);
         }
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,6 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.profiles.active=prod
 plant.net.api=${PLANT_NET_API}
 plant.book.api=${PLANT_BOOK_API}
-jwt.secret=${JWT_SECRET_KEY}
 
 florae.cookie.policy=lax
 

--- a/src/test/java/pl/Dayfit/Florae/Services/JWTServiceTest.java
+++ b/src/test/java/pl/Dayfit/Florae/Services/JWTServiceTest.java
@@ -11,13 +11,11 @@ import org.junit.jupiter.api.Test;
 import pl.Dayfit.Florae.Services.Auth.JWT.JWTService;
 import pl.Dayfit.Florae.Services.Auth.JWT.SecretKeysService;
 
-import java.lang.reflect.Field;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -27,22 +25,15 @@ class JWTServiceTest {
     private final SecretKeysService secretKeysService = new SecretKeysService();
 
     @BeforeEach
-    void setUp() throws Exception{
+    void setUp() {
         BlacklistJwtTokenRepository mockRepository = mock(BlacklistJwtTokenRepository.class);
         FloraeKeyLocator floraeKeyLocator = mock(FloraeKeyLocator.class);
-
-        Field secretKeys = secretKeysService.getClass().getDeclaredField("secretKeys");
 
         //Test usage only
         String validBase64Secret = "R6c5DHhqgLHzaeePvpMVxG8NlayobaFrZXc03LSwXAw=";
         ConcurrentMap<Integer, String> newSecretKeys = new ConcurrentHashMap<>(Map.of(0, validBase64Secret));
-        secretKeys.setAccessible(true);
-        secretKeys.set(secretKeysService, newSecretKeys);
-
-        Field currentSecretKeyIndex = secretKeysService.getClass().getDeclaredField("currentSecretKeyIndex");
-        currentSecretKeyIndex.setAccessible(true);
-        AtomicInteger index = new AtomicInteger(0);
-        currentSecretKeyIndex.set(secretKeysService, index);
+        secretKeysService.setSecretKeys(newSecretKeys);
+        secretKeysService.setCurrentSecretKeyIndex(0);
 
         Mockito.when(floraeKeyLocator.locate(Mockito.any(Header.class)))
                 .thenAnswer(invocation -> secretKeysService.getCurrentSecretKey());

--- a/src/test/java/pl/Dayfit/Florae/Services/JWTServiceTest.java
+++ b/src/test/java/pl/Dayfit/Florae/Services/JWTServiceTest.java
@@ -1,33 +1,53 @@
 package pl.Dayfit.Florae.Services;
 
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.Header;
+import org.mockito.Mockito;
+import pl.Dayfit.Florae.Auth.FloraeKeyLocator;
 import pl.Dayfit.Florae.Repositories.JPA.BlacklistJwtTokenRepository;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import pl.Dayfit.Florae.Services.Auth.JWT.JWTService;
+import pl.Dayfit.Florae.Services.Auth.JWT.SecretKeysService;
 
-import javax.crypto.SecretKey;
 import java.lang.reflect.Field;
-import java.util.Base64;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 class JWTServiceTest {
-
     private JWTService jwtService;
-    private final String validBase64Secret = "R6c5DHhqgLHzaeePvpMVxG8NlayobaFrZXc03LSwXAw="; //Test usage only
+    private final SecretKeysService secretKeysService = new SecretKeysService();
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() throws Exception{
         BlacklistJwtTokenRepository mockRepository = mock(BlacklistJwtTokenRepository.class);
-        jwtService = new JWTService(mockRepository);
-        Field secretKeyField = JWTService.class.getDeclaredField("secretKey");
-        secretKeyField.setAccessible(true);
-        secretKeyField.set(jwtService, validBase64Secret);
+        FloraeKeyLocator floraeKeyLocator = mock(FloraeKeyLocator.class);
+
+        Field secretKeys = secretKeysService.getClass().getDeclaredField("secretKeys");
+
+        //Test usage only
+        String validBase64Secret = "R6c5DHhqgLHzaeePvpMVxG8NlayobaFrZXc03LSwXAw=";
+        ConcurrentMap<Integer, String> newSecretKeys = new ConcurrentHashMap<>(Map.of(0, validBase64Secret));
+        secretKeys.setAccessible(true);
+        secretKeys.set(secretKeysService, newSecretKeys);
+
+        Field currentSecretKeyIndex = secretKeysService.getClass().getDeclaredField("currentSecretKeyIndex");
+        currentSecretKeyIndex.setAccessible(true);
+        AtomicInteger index = new AtomicInteger(0);
+        currentSecretKeyIndex.set(secretKeysService, index);
+
+        Mockito.when(floraeKeyLocator.locate(Mockito.any(Header.class)))
+                .thenAnswer(invocation -> secretKeysService.getCurrentSecretKey());
+
+        jwtService = new JWTService(mockRepository , floraeKeyLocator, secretKeysService);
     }
 
     @Test
@@ -57,12 +77,17 @@ class JWTServiceTest {
     @Test
     void shouldInvalidateExpiredToken() {
         String username = "expiredUser";
-        SecretKey key = Keys.hmacShaKeyFor(Base64.getDecoder().decode(validBase64Secret));
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("keyId", 0);
+
         String expiredToken = Jwts.builder()
+                .header()
+                .add(headers)
+                .and()
                 .subject(username)
                 .issuedAt(new Date(System.currentTimeMillis() - 20000))
                 .expiration(new Date(System.currentTimeMillis() - 10000))
-                .signWith(key)
+                .signWith(secretKeysService.getCurrentSecretKey())
                 .compact();
         assertNull(jwtService.extractUsername(expiredToken));
         assertFalse(jwtService.validateAccessToken(expiredToken, username));


### PR DESCRIPTION
This pull request introduces a key rotation mechanism for JWT secret keys, enhances security by replacing static secret keys with dynamically managed ones, and updates related services and tests accordingly.

### Key Rotation Mechanism:

* Added `FloraeKeyLocator` to dynamically locate the correct secret key based on the `keyId` in JWT headers. (`src/main/java/pl/Dayfit/Florae/Auth/FloraeKeyLocator.java`, [src/main/java/pl/Dayfit/Florae/Auth/FloraeKeyLocator.javaR1-R26](diffhunk://#diff-51999387e7dc48be4f4695da5037ebdffd875e4bb696387cc38c155c8a68e4f2R1-R26))
* Implemented `SecretKeysService` to manage secret keys, generate new keys during rotation events, and provide the current secret key. (`src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/SecretKeysService.java`, [src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/SecretKeysService.javaR1-R60](diffhunk://#diff-cd0dbcab3ff75726409d0317fd4c0cca4a8a036e627a48f8b49ed2b14d75a8a5R1-R60))
* Introduced `JWTRotationService` to schedule daily secret key rotation and publish `JWTRotationEvent` to trigger key generation. (`src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/JWTRotationService.java`, [src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/JWTRotationService.javaR1-R24](diffhunk://#diff-f552eb84fc1b916f5b01af167078d77b83615a68c943e9c38b8fae3ca2747072R1-R24))

### JWT Service Updates:

* Replaced static secret key management with `FloraeKeyLocator` and `SecretKeysService` for signing and parsing JWT tokens. (`src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/JWTService.java`, [[1]](diffhunk://#diff-153900e447a73423dffd63f35ad94a272b033d23fb6197b600ecef24156a1d9fL7-R16) [[2]](diffhunk://#diff-153900e447a73423dffd63f35ad94a272b033d23fb6197b600ecef24156a1d9fL41-R41) [[3]](diffhunk://#diff-153900e447a73423dffd63f35ad94a272b033d23fb6197b600ecef24156a1d9fR52-L90) [[4]](diffhunk://#diff-153900e447a73423dffd63f35ad94a272b033d23fb6197b600ecef24156a1d9fL132-R140)
* Updated JWT headers to include `keyId` for identifying the correct secret key during validation. (`src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/JWTService.java`, [src/main/java/pl/Dayfit/Florae/Services/Auth/JWT/JWTService.javaR52-L90](diffhunk://#diff-153900e447a73423dffd63f35ad94a272b033d23fb6197b600ecef24156a1d9fR52-L90))

### Configuration Changes:

* Removed the static `jwt.secret` property from `application.properties`, as secret keys are now dynamically managed. (`src/main/resources/application.properties`, [src/main/resources/application.propertiesL6](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136L6))

### Testing Enhancements:

* Refactored `JWTServiceTest` to mock `FloraeKeyLocator` and dynamically manage secret keys using `SecretKeysService`. (`src/test/java/pl/Dayfit/Florae/Services/JWTServiceTest.java`, [src/test/java/pl/Dayfit/Florae/Services/JWTServiceTest.javaL4-R50](diffhunk://#diff-5f01de1e95119a716e6883614f86cd607ff036228285b122807712fca78f909bL4-R50))
* Updated tests to validate JWT tokens with dynamic headers and secret keys. (`src/test/java/pl/Dayfit/Florae/Services/JWTServiceTest.java`, [src/test/java/pl/Dayfit/Florae/Services/JWTServiceTest.javaL60-R90](diffhunk://#diff-5f01de1e95119a716e6883614f86cd607ff036228285b122807712fca78f909bL60-R90))

Closes #76 