### PR TITLE
Implement API key revocation event handling and update related services

### DIFF
--- a/src/main/java/pl/Dayfit/Florae/Entities/FloraLink.java
+++ b/src/main/java/pl/Dayfit/Florae/Entities/FloraLink.java
@@ -39,13 +39,6 @@ public class FloraLink {
     @Column(nullable = false)
     private String name;
 
-    @ManyToOne(cascade = CascadeType.ALL)
-    private FloraeUser owner;
-
-    @OneToOne
-    @JoinColumn(nullable = false)
-    private Plant linkedPlant;
-
     @OneToOne(mappedBy = "floraLink", cascade = CascadeType.ALL)
     private DailyReportData dailyReportData;
 }

--- a/src/main/java/pl/Dayfit/Florae/Entities/Plant.java
+++ b/src/main/java/pl/Dayfit/Florae/Entities/Plant.java
@@ -37,9 +37,6 @@ public class Plant {
     @Column(nullable = false, length = 50)
     private String pid;
 
-    @OneToOne(mappedBy = "linkedPlant", cascade = CascadeType.ALL)
-    private FloraLink linkedFloraLink;
-
     @OneToOne(mappedBy = "linkedPlant", cascade = CascadeType.ALL, orphanRemoval = true)
     private ApiKey linkedApiKey;
 

--- a/src/main/java/pl/Dayfit/Florae/Events/ApiKeyRevokedEvent.java
+++ b/src/main/java/pl/Dayfit/Florae/Events/ApiKeyRevokedEvent.java
@@ -1,0 +1,6 @@
+package pl.Dayfit.Florae.Events;
+
+import pl.Dayfit.Florae.Entities.ApiKey;
+
+public record ApiKeyRevokedEvent(ApiKey apiKey) {
+}

--- a/src/main/java/pl/Dayfit/Florae/Helpers/SpEL/FloraLinkHelper.java
+++ b/src/main/java/pl/Dayfit/Florae/Helpers/SpEL/FloraLinkHelper.java
@@ -1,0 +1,18 @@
+package pl.Dayfit.Florae.Helpers.SpEL;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import pl.Dayfit.Florae.Entities.FloraLink;
+import pl.Dayfit.Florae.Entities.FloraeUser;
+import pl.Dayfit.Florae.Services.FloraLinkCacheService;
+
+@SuppressWarnings("unused")
+@Component("floraLinkHelper")
+@RequiredArgsConstructor
+public class FloraLinkHelper {
+    private final FloraLinkCacheService cacheService;
+
+    public FloraeUser getOwner(FloraLink floraLink) {
+        return cacheService.getOwner(floraLink);
+    }
+}

--- a/src/main/java/pl/Dayfit/Florae/Repositories/JPA/FloraLinkRepository.java
+++ b/src/main/java/pl/Dayfit/Florae/Repositories/JPA/FloraLinkRepository.java
@@ -29,6 +29,6 @@ import java.util.Optional;
 public interface FloraLinkRepository extends JpaRepository<FloraLink, Integer> {
     @Query("SELECT a.linkedFloraLink FROM ApiKey a WHERE a.floraeUser.id = :ownerId")
     Optional<List<FloraLink>> findByOwnerId(Integer ownerId);
-    @Query("SELECT a FROM ApiKey a WHERE a.linkedFloraLink = :floraLink")
+    @Query("SELECT a.floraeUser FROM ApiKey a WHERE a.linkedFloraLink = :floraLink")
     Optional<FloraeUser> findOwnerByFloraLink(FloraLink floraLink);
 }

--- a/src/main/java/pl/Dayfit/Florae/Repositories/JPA/FloraLinkRepository.java
+++ b/src/main/java/pl/Dayfit/Florae/Repositories/JPA/FloraLinkRepository.java
@@ -7,6 +7,7 @@ import pl.Dayfit.Florae.Entities.FloraLink;
 import pl.Dayfit.Florae.Entities.FloraeUser;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Repository interface for managing {@code FloraLink} entities.
@@ -26,7 +27,8 @@ import java.util.List;
  */
 @Repository
 public interface FloraLinkRepository extends JpaRepository<FloraLink, Integer> {
-    List<FloraLink> findByOwner(FloraeUser owner);
-    @Query("SELECT f.linkedFloraLink FROM ApiKey f WHERE f.keyValue = :apiKey")
-    FloraLink findByApiKey(String apiKey);
+    @Query("SELECT a.linkedFloraLink FROM ApiKey a WHERE a.floraeUser.id = :ownerId")
+    Optional<List<FloraLink>> findByOwnerId(Integer ownerId);
+    @Query("SELECT a FROM ApiKey a WHERE a.linkedFloraLink = :floraLink")
+    Optional<FloraeUser> findOwnerByFloraLink(FloraLink floraLink);
 }

--- a/src/main/java/pl/Dayfit/Florae/Services/FloraLinkCacheService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/FloraLinkCacheService.java
@@ -68,7 +68,7 @@ public class FloraLinkCacheService {
     }
 
     @Transactional(readOnly = true)
-    @CacheEvict(value = "owner", key = "#floraLink.id")
+    @Cacheable(value = "owner", key = "#floraLink.id")
     public FloraeUser getOwner(FloraLink floraLink) {
         return floraLinkRepository.findOwnerByFloraLink(floraLink).orElse(null);
     }

--- a/src/main/java/pl/Dayfit/Florae/Services/FloraLinkCacheService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/FloraLinkCacheService.java
@@ -4,24 +4,28 @@ import lombok.AllArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
 import pl.Dayfit.Florae.DTOs.FloraLinkResponseDTO;
 import pl.Dayfit.Florae.Entities.FloraLink;
+import pl.Dayfit.Florae.Entities.FloraeUser;
+import pl.Dayfit.Florae.Events.ApiKeyRevokedEvent;
 import pl.Dayfit.Florae.Repositories.JPA.FloraLinkRepository;
-import pl.Dayfit.Florae.Services.Auth.JWT.FloraeUserCacheService;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Service class for managing FloraLink entities with caching support.
  * This class handles operations related to fetching and saving FloraLink
- * entities while utilizing Spring's caching mechanisms for performance
+ * entities while using Spring's caching mechanisms for performance
  * optimization.
  * <p>
  * Responsibilities:
  * - Fetching a FloraLink entity by its ID, with results stored in a cache
- *   for subsequent retrievals.
+ *   for later retrievals.
  * - Saving or updating a FloraLink entity and updating the cache with the
  *   new or modified entity data.
  * <p>
@@ -37,7 +41,6 @@ import java.util.List;
 @Service
 @AllArgsConstructor
 public class FloraLinkCacheService {
-    private final FloraeUserCacheService floraeUserCacheService;
     private final FloraLinkRepository floraLinkRepository;
 
     @Cacheable(value = "flora-link", key = "#floraLinkId")
@@ -50,16 +53,32 @@ public class FloraLinkCacheService {
     @Cacheable(value = "flora-links", key = "#ownerId")
     public List<FloraLinkResponseDTO> getOwnedFloraLinks(Integer ownerId)
     {
-        return floraLinkRepository.findByOwner(floraeUserCacheService.getFloraeUserById(ownerId)).stream().map(
-                floraLink -> new FloraLinkResponseDTO(floraLink.getId(), floraLink.getName())
-        ).toList();
+        return floraLinkRepository.findByOwnerId(ownerId).orElse(new ArrayList<>())
+                .stream()
+                .map(elem -> new FloraLinkResponseDTO(elem.getId(), elem.getName()))
+                .toList();
     }
 
     @Transactional
-    @CacheEvict(value = "flora-links", key = "#result.owner.id")
+    @CacheEvict(value = "flora-links", key = "@floraLinkHelper.getOwner(#floraLink)")
     @CachePut(value = "flora-link", key = "#floraLink.id")
     public FloraLink saveFloraLink(FloraLink floraLink)
     {
         return floraLinkRepository.save(floraLink);
+    }
+
+    @Transactional(readOnly = true)
+    @CacheEvict(value = "owner", key = "#floraLink.id")
+    public FloraeUser getOwner(FloraLink floraLink) {
+        return floraLinkRepository.findOwnerByFloraLink(floraLink).orElse(null);
+    }
+
+    @TransactionalEventListener
+    @Caching(evict = {
+            @CacheEvict(value = "flora-links", key = "@floraLinkHelper.getOwner(#event.apiKey().linkedFloraLink)"),
+            @CacheEvict(value = "flora-link", key = "#event.apiKey().linkedFloraLink.id")
+    })
+    public void handleApiKeyRevocation(ApiKeyRevokedEvent event) {
+        floraLinkRepository.delete(event.apiKey().getLinkedFloraLink());
     }
 }

--- a/src/main/java/pl/Dayfit/Florae/Services/FloraLinkService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/FloraLinkService.java
@@ -36,7 +36,6 @@ public class FloraLinkService {
     private final FloraLinkCacheService cacheService;
     private final DailyReportDataCacheService dailyReportDataCacheService;
     private final RedisTemplate<String, Object> redisTemplate;
-    private final FloraLinkCacheService floraLinkCacheService;
 
     @Transactional
     public void handleReportUpload(List<DailySensorDataDTO> uploadedData, Authentication auth) {
@@ -112,7 +111,7 @@ public class FloraLinkService {
         FloraeUser floraeUser = floraeUserCacheService.getFloraeUser(username);
         FloraLink floraLink = cacheService.getFloraLink(dto.getId());
 
-        if (!floraLinkCacheService.getOwner(floraLink).equals(floraeUser))
+        if (!cacheService.getOwner(floraLink).equals(floraeUser))
         {
             throw new AccessDeniedException("User is not the owner of this FloraLink! Cannot change name!");
         }

--- a/src/main/java/pl/Dayfit/Florae/Services/FloraLinkService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/FloraLinkService.java
@@ -36,6 +36,7 @@ public class FloraLinkService {
     private final FloraLinkCacheService cacheService;
     private final DailyReportDataCacheService dailyReportDataCacheService;
     private final RedisTemplate<String, Object> redisTemplate;
+    private final FloraLinkCacheService floraLinkCacheService;
 
     @Transactional
     public void handleReportUpload(List<DailySensorDataDTO> uploadedData, Authentication auth) {
@@ -49,7 +50,7 @@ public class FloraLinkService {
             report = new DailyReportData();
             report.setSensorDataList(new ArrayList<>());
             report.setFloraLink(cacheService.getFloraLink(floraLinkId));
-            report.setFloraeUser(floraeUserCacheService.getFloraeUser(((ApiKey) auth.getCredentials()).getLinkedFloraLink().getOwner().getUsername()));
+            report.setFloraeUser(floraeUserCacheService.getFloraeUser(((FloraeUser) auth.getPrincipal()).getUsername()));
         }
 
         report.getSensorDataList().clear();
@@ -111,7 +112,7 @@ public class FloraLinkService {
         FloraeUser floraeUser = floraeUserCacheService.getFloraeUser(username);
         FloraLink floraLink = cacheService.getFloraLink(dto.getId());
 
-        if (!floraLink.getOwner().equals(floraeUser))
+        if (!floraLinkCacheService.getOwner(floraLink).equals(floraeUser))
         {
             throw new AccessDeniedException("User is not the owner of this FloraLink! Cannot change name!");
         }

--- a/src/main/java/pl/Dayfit/Florae/Services/PlantCacheService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/PlantCacheService.java
@@ -6,7 +6,9 @@ import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
 import pl.Dayfit.Florae.Entities.Plant;
+import pl.Dayfit.Florae.Events.ApiKeyRevokedEvent;
 import pl.Dayfit.Florae.Repositories.JPA.PlantRepository;
 
 import java.util.List;
@@ -21,25 +23,31 @@ public class PlantCacheService {
     private final PlantRepository plantRepository;
 
     @Transactional(readOnly = true)
-    @Cacheable(value = "plants", key = "#id")
+    @Cacheable(value = "plant", key = "#id")
     public Plant getPlantById(int id)
     {
         return plantRepository.findById(id).orElse(null);
     }
 
-    @CacheEvict(value = "plants", key = "#plantId")
+    @CacheEvict(value = "plant", key = "#plantId")
     public void deletePlant(Integer plantId) {
         plantRepository.deleteById(plantId);
     }
 
-    @CachePut(value = "plants", key = "#plant.id")
+    @CachePut(value = "plant", key = "#plant.id")
     public Plant savePlant(Plant plant)
     {
         return plantRepository.save(plant);
     }
 
-    @Cacheable(value = "user-plants", key = "#username")
+    @Cacheable(value = "plants", key = "#username")
     public List<Plant> getAllPlants(String username) {
         return plantRepository.getPlantsByUsername(username);
+    }
+
+    @SuppressWarnings("unused")
+    @TransactionalEventListener
+    @CacheEvict(value = "plant", key = "#event.apiKey().getLinkedPlant().getId()")
+    public void handleApiKeyRevocation(ApiKeyRevokedEvent event) {
     }
 }

--- a/src/main/java/pl/Dayfit/Florae/Services/PlantsService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/PlantsService.java
@@ -127,7 +127,7 @@ public class PlantsService {
             return null;
         }
 
-        FloraLink floraLink = plant.getLinkedFloraLink();
+        FloraLink floraLink = plant.getLinkedApiKey().getLinkedFloraLink();
         FloraLinkResponseDTO floraLinkResponseDTO = null;
 
         if(floraLink != null)


### PR DESCRIPTION
This pull request introduces significant changes to the `FloraLink` and `Plant` entity relationships, refactors caching and event handling logic, and improves the management of API keys. The most notable updates include removing direct ownership and linking relationships from `FloraLink` and `Plant`, introducing event-driven mechanisms for handling API key revocation, and optimizing caching strategies.

### Entity Relationship Refactoring:
* Removed the `owner` and `linkedPlant` fields from `FloraLink`, and the `linkedFloraLink` field from `Plant`, simplifying their relationships. (`src/main/java/pl/Dayfit/Florae/Entities/FloraLink.java` - [[1]](diffhunk://#diff-6bd31906f89141e046953b39e9b436ac940a0d38f3587026efcbfa123ab6fa1aL42-L48) `src/main/java/pl/Dayfit/Florae/Entities/Plant.java` - [[2]](diffhunk://#diff-ed7914a8484f07e46eba4d99c765ac6e93d89dd066b2163536ade61ee3b9bb2eL40-L42)

### Event-Driven API Key Revocation:
* Added `ApiKeyRevokedEvent` to handle API key revocation events, including cascading updates to related entities. (`src/main/java/pl/Dayfit/Florae/Events/ApiKeyRevokedEvent.java` - [src/main/java/pl/Dayfit/Florae/Events/ApiKeyRevokedEvent.javaR1-R6](diffhunk://#diff-23322f9a85ad7f1235ef0c65664cb3f6b8b16511142ec0b8c0a0e89f08136806R1-R6))
* Updated `ApiKeyCacheService` to publish `ApiKeyRevokedEvent` and set `linkedFloraLink` to `null` during API key revocation. (`src/main/java/pl/Dayfit/Florae/Services/Auth/API/ApiKeyCacheService.java` - [src/main/java/pl/Dayfit/Florae/Services/Auth/API/ApiKeyCacheService.javaR67-R71](diffhunk://#diff-4501bed33a0fff39d9ba737f9eff78de0da5b584ae755cc74377e522262f895cR67-R71))

### Caching Enhancements:
* Refactored `FloraLinkCacheService` to use helper methods for retrieving owners and added transactional event handling for API key revocation. (`src/main/java/pl/Dayfit/Florae/Services/FloraLinkCacheService.java` - [[1]](diffhunk://#diff-cf9ae708ab99d81bfeacf37984ddcd0d60ebecc31cd7858d69c4586a74622ab9L53-R83) [[2]](diffhunk://#diff-cf9ae708ab99d81bfeacf37984ddcd0d60ebecc31cd7858d69c4586a74622ab9L40)
* Updated `PlantCacheService` to handle API key revocation events and optimized caching annotations. (`src/main/java/pl/Dayfit/Florae/Services/PlantCacheService.java` - [src/main/java/pl/Dayfit/Florae/Services/PlantCacheService.javaL24-R52](diffhunk://#diff-3138ae11d4bdf4176cf6c220d79a96e43eca3df6361eccf2aa6b474db7281dddL24-R52))

### Repository Updates:
* Modified `FloraLinkRepository` to use `ownerId` for querying and added methods for retrieving owners by `FloraLink`. (`src/main/java/pl/Dayfit/Florae/Repositories/JPA/FloraLinkRepository.java` - [src/main/java/pl/Dayfit/Florae/Repositories/JPA/FloraLinkRepository.javaL29-R33](diffhunk://#diff-7a429a839738a9e13cdbc6f87d7b166f90f8b4eb7d964b4d6a30007d83f9f52fL29-R33))

### API Key Management Improvements:
* Refactored `ApiKeyService` to streamline API key generation and linking logic, ensuring proper handling of linked entities. (`src/main/java/pl/Dayfit/Florae/Services/Auth/API/ApiKeyService.java` - [[1]](diffhunk://#diff-2512f6b2cfe1d19b0f4d51f46e5bd38a1a17513d66415d62bc71c60cea7e32a3R59-R89) [[2]](diffhunk://#diff-2512f6b2cfe1d19b0f4d51f46e5bd38a1a17513d66415d62bc71c60cea7e32a3L132-L138)

closes #81 