### PR TITLE
frontend-changing-post-request

### DIFF
--- a/florae-frontend/src/Components/devices-page.jsx
+++ b/florae-frontend/src/Components/devices-page.jsx
@@ -20,7 +20,6 @@ import { devicesGuestContent, devicesVisitorContent } from '../util/devices-page
 import axios from 'axios';
 import DevicesCard from './devices-card.jsx';
 import EspConfiguration from './esp-configuration.jsx';
-import Button from './button.jsx';
 
 export default function DevicesPage({ setModal }) {
   const { isLogged } = use(UserContext);
@@ -64,9 +63,9 @@ export default function DevicesPage({ setModal }) {
       <div className="bg-gray-50 m-[4vw] rounded-lg shadow-lg min-h-250">
         <InformationComponent
           setModal={setModal}
-          handleTask={ handleEspConfig }
-          guestContent={ devicesGuestContent }
-          visitorContent={ devicesVisitorContent }
+          handleTask={handleEspConfig}
+          guestContent={devicesGuestContent}
+          visitorContent={devicesVisitorContent}
           showFor="both"
         />
         {isLogged && (

--- a/florae-frontend/src/Components/useCreatePlant.jsx
+++ b/florae-frontend/src/Components/useCreatePlant.jsx
@@ -68,7 +68,7 @@ export default function useCreatePlant({ onClose }) {
         } catch (err) {
             setErrors((prev) => ({
                 ...prev,
-                submit: 'Failed to create plant. Try again later. ' + err.message,
+                submit: 'Failed to create plant. Try again later. ',
             }));
         } finally {
             setSubmitting(false);

--- a/florae-frontend/src/Components/useCreatePlant.jsx
+++ b/florae-frontend/src/Components/useCreatePlant.jsx
@@ -9,6 +9,21 @@ export default function useCreatePlant({ onClose }) {
     const [errors, setErrors] = useState({});
     const [submitting, setSubmitting] = useState(false);
 
+    const setPlantName = async (plantId, name) => {
+      console.log('Setting plant name:', plantId, name);
+      const csrfToken = await getCsrfToken();
+      await axios.put(
+        '/api/v1/plant-set-name',
+        { plantId, name },
+        {
+          headers: {
+            'X-XSRF-TOKEN': csrfToken,
+          },
+          withCredentials: true,
+        }
+      );
+    };
+
     const handleSubmit = async (e) => {
         e.preventDefault();
 
@@ -40,38 +55,24 @@ export default function useCreatePlant({ onClose }) {
                 },
                 withCredentials: true,
             });
-
-            const plantId = response.data?.id;
-
-            if (plantId) {
-                try {
-                    const csrfToken = await getCsrfToken();
-
-                    axios.post(
-                        '/api/v1/plant-set-name',
-                        { plantId: plantId, name: nameRef.current.value },
-                        {
-                            headers: {
-                                'X-XSRF-TOKEN': csrfToken,
-                            },
-                            withCredentials: true,
-                        }
-                    );
-                // eslint-disable-next-line no-unused-vars
-                } catch (e) {
-                    console.error('Failed to set plant name:');
-                }
+            console.log('e')
+            try {
+                await setPlantName(response.data.id, nameRef.current.value)
+            // eslint-disable-next-line no-unused-vars
+            } catch (e) {
+                console.error('Failed to set plant name:');
             }
+
             onClose();
         // eslint-disable-next-line no-unused-vars
         } catch (err) {
             setErrors((prev) => ({
                 ...prev,
-                submit: 'Failed to create plant. Try again later.',
+                submit: 'Failed to create plant. Try again later. ' + err.message,
             }));
         } finally {
             setSubmitting(false);
         }
     };
-    return({nameRef, fileRef, errors, submitting, handleSubmit})
+    return({nameRef, fileRef, errors, submitting, handleSubmit, setPlantName})
 }


### PR DESCRIPTION
This pull request introduces changes to the `florae-frontend` codebase, focusing on improving the modularity and reusability of the `useCreatePlant` hook and simplifying the `DevicesPage` component. The most important changes include the removal of unused imports, the extraction of functionality into a reusable function, and adjustments to the returned values of the `useCreatePlant` hook.

### DevicesPage Simplification:
* Removed the unused `Button` import from the `DevicesPage` component to clean up the code and reduce unnecessary dependencies. (`florae-frontend/src/Components/devices-page.jsx`, [florae-frontend/src/Components/devices-page.jsxL23](diffhunk://#diff-3772cd3e3b22969f64eb127903742519705622d3120d503818a07eeaa8c57a0eL23))

### Improvements to `useCreatePlant` Hook:
* Extracted the logic for setting a plant's name into a new reusable function, `setPlantName`, to improve modularity and reduce code duplication. (`florae-frontend/src/Components/useCreatePlant.jsx`, [florae-frontend/src/Components/useCreatePlant.jsxR12-R26](diffhunk://#diff-6b4e851fb36916bec254f9b82131a98457c89bebd398704faca5f6b777586e5fR12-R26))
* Refactored the `handleSubmit` function to use the new `setPlantName` function, simplifying the implementation and improving readability. (`florae-frontend/src/Components/useCreatePlant.jsx`, [florae-frontend/src/Components/useCreatePlant.jsxL43-R65](diffhunk://#diff-6b4e851fb36916bec254f9b82131a98457c89bebd398704faca5f6b777586e5fL43-R65))
* Updated the return object of the `useCreatePlant` hook to include the new `setPlantName` function, making it accessible for external use. (`florae-frontend/src/Components/useCreatePlant.jsx`, [florae-frontend/src/Components/useCreatePlant.jsxL76-R77](diffhunk://#diff-6b4e851fb36916bec254f9b82131a98457c89bebd398704faca5f6b777586e5fL76-R77))