### PR TITLE
Add null check for GenerateApiKeyDTO and improve session unregistration logic

### DIFF
--- a/src/main/java/pl/Dayfit/Florae/Controllers/ApiKeyController.java
+++ b/src/main/java/pl/Dayfit/Florae/Controllers/ApiKeyController.java
@@ -33,6 +33,11 @@ public class ApiKeyController {
     @PostMapping("/api/v1/generate-key")
     public ResponseEntity<Map<String, String>> generateApiKey(@RequestBody GenerateApiKeyDTO apiKeyDTO, @AuthenticationPrincipal UserPrincipal userPrincipal) throws AssociationException
     {
+        if (apiKeyDTO == null)
+        {
+            throw new IllegalArgumentException("Incorrect request body");
+        }
+
         Plant plant = plantCacheService.getPlantById(apiKeyDTO.getPlantId());
 
         if (plant == null)

--- a/src/main/java/pl/Dayfit/Florae/Services/WebSockets/SessionService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/WebSockets/SessionService.java
@@ -80,13 +80,13 @@ public class SessionService {
 
         if (connectionType == ConnectionType.USER)
         {
-            if (!floralinkSessions.containsKey(session.getId()))
+            if (!userSessions.containsKey(session.getId()))
             {
                 log.debug("User Session id was not in session map, at {}", session.getId());
                 return;
             }
 
-            floralinkSessions.remove(session.getId());
+            userSessions.remove(session.getId());
         }
     }
 

--- a/src/main/java/pl/Dayfit/Florae/Services/WebSockets/SessionService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/WebSockets/SessionService.java
@@ -3,7 +3,6 @@ package pl.Dayfit.Florae.Services.WebSockets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.WebSocketSession;
 import pl.Dayfit.Florae.Enums.ConnectionType;
@@ -17,7 +16,6 @@ import java.util.concurrent.ConcurrentHashMap;
 @Service
 @RequiredArgsConstructor
 public class SessionService {
-    private final RedisTemplate<String, Object> redisTemplate;
     private final ConcurrentHashMap<String, WebSocketSession> userSessions = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, WebSocketSession> floralinkSessions = new ConcurrentHashMap<>();
 
@@ -65,10 +63,31 @@ public class SessionService {
     public void unregisterSession(WebSocketConnectionClosedEvent event)
     {
         WebSocketSession session = event.session();
-
+        ConnectionType connectionType = event.connectionType();
         log.trace("Handling session unregister id: {}", session.getId());
 
-        redisTemplate.delete((String) session.getAttributes().get(event.connectionType() == ConnectionType.FLORALINK ? "linkedPlantId" : "username"));
+
+        if (connectionType == ConnectionType.FLORALINK)
+        {
+            if (!floralinkSessions.containsKey(session.getId()))
+            {
+                log.debug("FloraLink Session id was not in session map, at {}", session.getId());
+                return;
+            }
+
+            floralinkSessions.remove(session.getId());
+        }
+
+        if (connectionType == ConnectionType.USER)
+        {
+            if (!floralinkSessions.containsKey(session.getId()))
+            {
+                log.debug("User Session id was not in session map, at {}", session.getId());
+                return;
+            }
+
+            floralinkSessions.remove(session.getId());
+        }
     }
 
     public WebSocketSession getFloralinkSessionById(String floraLinkId)


### PR DESCRIPTION
This pull request includes changes to improve input validation, remove unused dependencies, and refactor session management logic. The most important changes focus on ensuring robust error handling, simplifying the codebase, and enhancing maintainability.

### Input Validation Improvements:
* Added a null check for the `GenerateApiKeyDTO` object in the `generateApiKey` method of `ApiKeyController` to throw an `IllegalArgumentException` if the request body is incorrect. (`src/main/java/pl/Dayfit/Florae/Controllers/ApiKeyController.java`, [src/main/java/pl/Dayfit/Florae/Controllers/ApiKeyController.javaR36-R40](diffhunk://#diff-58ccac52279f34b3e64d651041df8f0300ecb6fd53c227d3e4edaf356ba845d0R36-R40))

### Codebase Simplification:
* Removed the unused `RedisTemplate` dependency from the `SessionService` class and its imports, reducing unnecessary code. (`src/main/java/pl/Dayfit/Florae/Services/WebSockets/SessionService.java`, [[1]](diffhunk://#diff-43506c1fba2702e5a8717fbf383759c937109cc8e740933ed9afbb7d87bdb0a1L6) [[2]](diffhunk://#diff-43506c1fba2702e5a8717fbf383759c937109cc8e740933ed9afbb7d87bdb0a1L20)

### Session Management Refactor:
* Refactored the `unregisterSession` method in `SessionService` to replace `RedisTemplate` operations with in-memory session map checks (`floralinkSessions` and `userSessions`). This change improves clarity and removes reliance on Redis for session management. (`src/main/java/pl/Dayfit/Florae/Services/WebSockets/SessionService.java`, [src/main/java/pl/Dayfit/Florae/Services/WebSockets/SessionService.javaL68-R90](diffhunk://#diff-43506c1fba2702e5a8717fbf383759c937109cc8e740933ed9afbb7d87bdb0a1L68-R90))