### PR TITLE
Refactor ApiKeyService and update application properties for improved functionality and error handling

### DIFF
--- a/Floralink/src/floralink.cpp
+++ b/Floralink/src/floralink.cpp
@@ -173,7 +173,7 @@ void handleWebSocketEvent(WStype_t type, uint8_t *payload, size_t length)
 
         Serial.println(commandType);
 
-        if (commandType.equalsIgnoreCase("ADD_WATER"))
+        if (commandType.equalsIgnoreCase("WATERING"))
         {
           handleAddingWater(doc["value"]);
         }

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,7 @@ services:
     container_name: spring
     depends_on:
       - postgres
+      - redis
     environment:
       - 'DB_NAME=${DB_NAME}'
       - 'POSTGRES_PASSWORD=${POSTGRES_PASSWORD}'
@@ -30,7 +31,7 @@ services:
       - spring
     profiles:
       - prod
-
+      
   watchtower:
     image: 'containrrr/watchtower:1.7.1'
     environment:
@@ -54,6 +55,19 @@ services:
     profiles:
       - prod
 
+  postgres-local-prod:
+    image: 'postgres:15-alpine3.20'
+    environment:
+      - 'POSTGRES_DB=${DB_NAME}'
+      - 'POSTGRES_PASSWORD=${POSTGRES_PASSWORD}'
+      - 'POSTGRES_USER=${POSTGRES_USER}'
+    volumes:
+      - './pgdata:/var/lib/pgsql/data'
+    ports:
+      - '5432:5432'
+    profiles:
+      - local-prod
+
   postgres-dev:
     image: 'postgres:15-alpine3.20'
     ports:
@@ -71,6 +85,15 @@ services:
       - 'REDIS_PASSWORD=${REDIS_PASSWORD}'
     profiles:
       - prod
+
+  redis-local-prod:
+    image: 'bitnami/redis:8.0.1'
+    environment:
+      - 'REDIS_PASSWORD=${REDIS_PASSWORD}'
+    ports:
+      - '6379:6379'
+    profiles:
+      - local-prod
 
   redis-dev:
     image: 'redis:8.0.1-bookworm'

--- a/dockerfiles/spring/Dockerfile
+++ b/dockerfiles/spring/Dockerfile
@@ -11,5 +11,8 @@ RUN mvn clean package -DskipTests
 ## Relocate and Rename the Jar-file
 RUN mv /app/target/Florae*.jar Florae.jar
 
+ENV SPRING_PROFILES_ACTIVE=prod
+EXPOSE 8080
+
 ## Run the jar-file
 CMD sh -c 'java -jar Florae.jar'

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
     limit_req_zone $binary_remote_addr zone=ip_limit:10m rate=10r/s;
+    client_max_body_size 51M;
 
     server {
         listen 443 ssl;

--- a/src/main/java/pl/Dayfit/Florae/Entities/FloraeUser.java
+++ b/src/main/java/pl/Dayfit/Florae/Entities/FloraeUser.java
@@ -57,7 +57,7 @@ public class FloraeUser {
     @Column(nullable = false, length = MAX_PASSWORD_LENGTH)
     private String password;
 
-    @OneToMany(mappedBy = "linkedUser", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "linkedUser", cascade = CascadeType.ALL)
     private List<Plant> linkedPlants;
 
     @Column(nullable = false)

--- a/src/main/java/pl/Dayfit/Florae/Services/Auth/API/ApiKeyService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/Auth/API/ApiKeyService.java
@@ -70,20 +70,14 @@ public class ApiKeyService {
             cacheService.save(linkedApiKey);
         }
 
-        else if (linkedApiKey.getLinkedFloraLink() != null)
-        {
-            throw new AssociationException("Plant is already linked to a FloraLink");
-        }
-
         else
         {
             linkedApiKey.setCreatedDate(Instant.now());
             linkedApiKey.setKeyValue(encryptedUUID);
             linkedApiKey.setShortKey(apiKeyHelper.generateShortKey(generatedUUID));
             linkedApiKey.setIsRevoked(false);
-            cacheService.saveAndFlush(linkedApiKey);
 
-            return generatedUUID;
+            cacheService.saveAndFlush(linkedApiKey);
         }
 
         final ApiKey apiKey = linkedApiKey;
@@ -132,11 +126,6 @@ public class ApiKeyService {
     @Transactional
     public void connectApi(Authentication authentication) throws AssociationException {
         ApiKey apiKey = apiKeyCacheService.getApiKeyByHash(((ApiKey) authentication.getCredentials()).getKeyValue());
-
-        if (apiKey.getLinkedFloraLink() != null)
-        {
-            throw new AssociationException("This API key is already linked to a FloraLink");
-        }
 
         FloraLink floraLink = new FloraLink();
         floraLink.setId(null);

--- a/src/main/resources/application-local-prod.properties
+++ b/src/main/resources/application-local-prod.properties
@@ -1,0 +1,21 @@
+spring.docker.compose.enabled=true
+spring.docker.compose.profiles.active=local-prod
+
+allowed.origins.patterns=${ALLOWED_ORIGINS_PATTERNS}
+
+spring.datasource.url=jdbc:postgresql://postgres:5432/${DB_NAME}
+
+server.forward-headers-strategy=framework
+
+spring.datasource.username=${POSTGRES_USER}
+spring.datasource.password=${POSTGRES_PASSWORD}
+spring.jpa.hibernate.ddl-auto=create-drop
+
+spring.data.redis.host=redis
+spring.data.redis.port=6379
+spring.data.redis.password=${REDIS_PASSWORD}
+spring.cache.type=redis
+
+logging.level.org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver = error
+
+florae.forwarded-headers.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,8 +6,8 @@ plant.book.api=${PLANT_BOOK_API}
 
 florae.cookie.policy=lax
 
-spring.servlet.multipart.max-request-size=50MB
-spring.servlet.multipart.max-file-size=50MB
+spring.servlet.multipart.max-request-size=51MB
+spring.servlet.multipart.max-file-size=51MB
 
 security.protected-paths=/auth/logout,/api/v1/add-plant,/api/v1/plants,/api/v1/get-user-data,\
   /api/v1/delete-plant/,/api/v1/plant-set-name,/api/v1/generate-key,\


### PR DESCRIPTION
This pull request introduces several updates to improve functionality, configuration, and code maintainability across various components of the project. The key changes include updates to the `docker-compose` configuration for enhanced environment support, adjustments to the API key service logic, and modifications to file upload limits and user entity relationships.

### Environment and Configuration Updates:
* Added `redis` as a dependency in `compose.yaml` and introduced `redis-local-prod` and `postgres-local-prod` services for the `local-prod` profile. These changes enable better support for production-like local environments. [[1]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR7) [[2]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR58-R70) [[3]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR89-R97)
* Updated `application-local-prod.properties` to include configurations for Redis, PostgreSQL, and Docker Compose profiles. This ensures proper connectivity and environment-specific settings.
* Added `SPRING_PROFILES_ACTIVE=prod` and exposed port `8080` in the Spring `Dockerfile`. This prepares the application for deployment in a production environment.

### Code Logic and Behavior Adjustments:
* Updated the API key generation and connection logic in `ApiKeyService` by removing redundant checks for FloraLink associations. This simplifies the code and avoids unnecessary exceptions. [[1]](diffhunk://#diff-2512f6b2cfe1d19b0f4d51f46e5bd38a1a17513d66415d62bc71c60cea7e32a3L73-R80) [[2]](diffhunk://#diff-2512f6b2cfe1d19b0f4d51f46e5bd38a1a17513d66415d62bc71c60cea7e32a3L136-L140)
* Renamed the WebSocket command `ADD_WATER` to `WATERING` in `floralink.cpp` for better clarity and consistency.

### File Upload and User Entity Changes:
* Increased the maximum file upload size to `51MB` in both `application.properties` and `nginx.conf` to accommodate larger payloads. [[1]](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136L9-R10) [[2]](diffhunk://#diff-1f91f64bfa3fb0a1ece881887af0a2356b8c529a96fb91c1894745b2a1a009aaR7)
* Removed the `orphanRemoval` attribute from the `linkedPlants` relationship in `FloraeUser` to allow more flexible handling of associated plants.