### PR TITLE
Add wateringDate to FloraLink and update watering logic in FloraLinkService

### DIFF
--- a/src/main/java/pl/Dayfit/Florae/Entities/FloraLink.java
+++ b/src/main/java/pl/Dayfit/Florae/Entities/FloraLink.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.Instant;
+
 /**
  * Represents an ESP device entity in the system.
  * This class is used to map ESP-related data to the database.
@@ -37,4 +39,7 @@ public class FloraLink {
 
     @Column(nullable = false)
     private String name;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Instant wateringDate;
 }

--- a/src/main/java/pl/Dayfit/Florae/Entities/FloraLink.java
+++ b/src/main/java/pl/Dayfit/Florae/Entities/FloraLink.java
@@ -40,6 +40,5 @@ public class FloraLink {
     @Column(nullable = false)
     private String name;
 
-    @Temporal(TemporalType.TIMESTAMP)
     private Instant wateringDate;
 }

--- a/src/main/java/pl/Dayfit/Florae/Services/FloraLinkService.java
+++ b/src/main/java/pl/Dayfit/Florae/Services/FloraLinkService.java
@@ -62,7 +62,7 @@ public class FloraLinkService {
 
         FloraLink floraLink = cacheService.getFloraLink(floraLinkId);
 
-        if (soilMoistureData != null && minimalSoilMoisture != null && linkedPlant.getRequirements().getMinSoilMoist() > soilMoistureData.getValue() && Duration.between(floraLink.getWateringDate(), Instant.now()).toMinutes() > 30)
+        if (soilMoistureData != null && minimalSoilMoisture != null && linkedPlant.getRequirements().getMinSoilMoist() > soilMoistureData.getValue() && (floraLink.getWateringDate() == null || Duration.between(floraLink.getWateringDate(), Instant.now()).toMinutes() > 30))
         {
             redisTemplate.convertAndSend("floralink." + floraLinkId, new CommandMessage(
                     CommandType.WATERING,


### PR DESCRIPTION
This pull request introduces a new feature to track the last watering date of a `FloraLink` entity and updates the logic in `FloraLinkService` to incorporate this data when determining whether to send a watering command. The changes include adding a new field to the `FloraLink` entity, updating service logic, and ensuring proper imports.

### Entity Updates:
* Added a new `wateringDate` field of type `Instant` to the `FloraLink` entity, annotated with `@Temporal(TemporalType.TIMESTAMP)` to store the last watering timestamp. (`src/main/java/pl/Dayfit/Florae/Entities/FloraLink.java`, [[1]](diffhunk://#diff-6bd31906f89141e046953b39e9b436ac940a0d38f3587026efcbfa123ab6fa1aR7-R8) [[2]](diffhunk://#diff-6bd31906f89141e046953b39e9b436ac940a0d38f3587026efcbfa123ab6fa1aR42-R44)

### Service Logic Enhancements:
* Updated the `handleCurrentDataUpload` method in `FloraLinkService` to:
  * Check if the time since the last watering exceeds 30 minutes before sending a watering command. (`src/main/java/pl/Dayfit/Florae/Services/FloraLinkService.java`, [src/main/java/pl/Dayfit/Florae/Services/FloraLinkService.javaL61-R65](diffhunk://#diff-a1129e37ac84a1fb70523739f3943fd544cade61a4598ffdc786b936562635ecL61-R65))
  * Set the `wateringDate` field to the current timestamp when a watering command is sent. (`src/main/java/pl/Dayfit/Florae/Services/FloraLinkService.java`, [src/main/java/pl/Dayfit/Florae/Services/FloraLinkService.javaR76-R77](diffhunk://#diff-a1129e37ac84a1fb70523739f3943fd544cade61a4598ffdc786b936562635ecR76-R77))

### Import Adjustments:
* Added necessary imports for `Instant` and `Duration` to support the new feature. (`src/main/java/pl/Dayfit/Florae/Services/FloraLinkService.java`, [src/main/java/pl/Dayfit/Florae/Services/FloraLinkService.javaR24-R25](diffhunk://#diff-a1129e37ac84a1fb70523739f3943fd544cade61a4598ffdc786b936562635ecR24-R25))